### PR TITLE
[FEATURE] #18 - 메인화면 '기획전 이외 탭' Data Layer단 구성하기 

### DIFF
--- a/app/src/main/java/com/seom/banchan/data/api/MenuApiService.kt
+++ b/app/src/main/java/com/seom/banchan/data/api/MenuApiService.kt
@@ -1,10 +1,20 @@
 package com.seom.banchan.data.api
 
 import com.seom.banchan.data.api.response.BestMenuResponse
+import com.seom.banchan.data.api.response.MenuResponse
 import retrofit2.Response
 import retrofit2.http.GET
 
 interface MenuApiService {
     @GET("best")
     suspend fun getBestMenus(): Response<BestMenuResponse>
+
+    @GET("main")
+    suspend fun getMainMenus(): Response<MenuResponse>
+
+    @GET("soup")
+    suspend fun getSoupMenus(): Response<MenuResponse>
+
+    @GET("side")
+    suspend fun getSideMenus(): Response<MenuResponse>
 }

--- a/app/src/main/java/com/seom/banchan/data/api/response/MenuResponse.kt
+++ b/app/src/main/java/com/seom/banchan/data/api/response/MenuResponse.kt
@@ -1,0 +1,5 @@
+package com.seom.banchan.data.api.response
+
+data class MenuResponse(
+    val body: List<Menu>
+)

--- a/app/src/main/java/com/seom/banchan/data/repository/MenuRepositoryImpl.kt
+++ b/app/src/main/java/com/seom/banchan/data/repository/MenuRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.seom.banchan.data.repository
 
-import android.util.Log
 import com.seom.banchan.data.source.MenuDataSource
 import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
 import com.seom.banchan.domain.repository.MenuRepository
 import javax.inject.Inject
 
@@ -10,8 +10,18 @@ class MenuRepositoryImpl @Inject constructor(
     private val menuDataSource: MenuDataSource
 ) : MenuRepository {
     override suspend fun getBestMenus(): Result<List<CategoryModel>> {
-        val response = menuDataSource.getBestMenus()
-        Log.d("Repository", response.toString())
         return menuDataSource.getBestMenus()
+    }
+
+    override suspend fun getMainMenus(): Result<List<MenuModel>>  {
+        return menuDataSource.getMainMenus()
+    }
+
+    override suspend fun getSoupMenus(): Result<List<MenuModel>>  {
+        return menuDataSource.getSoupMenus()
+    }
+
+    override suspend fun getSideMenus(): Result<List<MenuModel>>  {
+        return menuDataSource.getSideMenus()
     }
 }

--- a/app/src/main/java/com/seom/banchan/data/source/MenuDataSource.kt
+++ b/app/src/main/java/com/seom/banchan/data/source/MenuDataSource.kt
@@ -1,11 +1,17 @@
 package com.seom.banchan.data.source
 
-import com.seom.banchan.data.api.response.BestMenuResponse
 import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
 
 /**
  * 메뉴에만 관련된 요청 관리
  */
 interface MenuDataSource {
     suspend fun getBestMenus(): Result<List<CategoryModel>>
+
+    suspend fun getMainMenus(): Result<List<MenuModel>>
+
+    suspend fun getSoupMenus(): Result<List<MenuModel>>
+
+    suspend fun getSideMenus(): Result<List<MenuModel>>
 }

--- a/app/src/main/java/com/seom/banchan/data/source/remote/MenuDataSourceImpl.kt
+++ b/app/src/main/java/com/seom/banchan/data/source/remote/MenuDataSourceImpl.kt
@@ -5,6 +5,7 @@ import com.seom.banchan.data.api.response.BestMenuResponse
 import com.seom.banchan.data.api.response.toModel
 import com.seom.banchan.data.source.MenuDataSource
 import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
 import javax.inject.Inject
 
 class MenuDataSourceImpl @Inject constructor(
@@ -12,11 +13,58 @@ class MenuDataSourceImpl @Inject constructor(
 ) : MenuDataSource {
     override suspend fun getBestMenus(): Result<List<CategoryModel>> = try {
         val response = menuApiService.getBestMenus()
-        println(response)
         if (response.isSuccessful) {
             val result = response.body()
             if (result != null) {
                 Result.success(result.body.map { category -> category.toModel() })
+            } else {
+                Result.success(emptyList())
+            }
+        } else {
+            throw Exception()
+        }
+    } catch (exception: Exception) {
+        Result.failure<Nothing>(exception)
+    }
+
+    override suspend fun getMainMenus(): Result<List<MenuModel>> = try {
+        val response = menuApiService.getMainMenus()
+        if (response.isSuccessful) {
+            val result = response.body()
+            if (result != null) {
+                Result.success(result.body.map { menu -> menu.toModel() })
+            } else {
+                Result.success(emptyList())
+            }
+        } else {
+            throw Exception()
+        }
+    } catch (exception: Exception) {
+        Result.failure<Nothing>(exception)
+    }
+
+    override suspend fun getSoupMenus(): Result<List<MenuModel>> = try {
+        val response = menuApiService.getSoupMenus()
+        if (response.isSuccessful) {
+            val result = response.body()
+            if (result != null) {
+                Result.success(result.body.map { menu -> menu.toModel() })
+            } else {
+                Result.success(emptyList())
+            }
+        } else {
+            throw Exception()
+        }
+    } catch (exception: Exception) {
+        Result.failure<Nothing>(exception)
+    }
+
+    override suspend fun getSideMenus(): Result<List<MenuModel>> = try {
+        val response = menuApiService.getSideMenus()
+        if (response.isSuccessful) {
+            val result = response.body()
+            if (result != null) {
+                Result.success(result.body.map { menu -> menu.toModel() })
             } else {
                 Result.success(emptyList())
             }

--- a/app/src/main/java/com/seom/banchan/domain/repository/MenuRepository.kt
+++ b/app/src/main/java/com/seom/banchan/domain/repository/MenuRepository.kt
@@ -1,11 +1,17 @@
 package com.seom.banchan.domain.repository
 
-import com.seom.banchan.data.api.response.BestMenuResponse
 import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
 
 interface MenuRepository {
     /**
      * 기획전 메뉴 정보 요청
      */
     suspend fun getBestMenus(): Result<List<CategoryModel>>
+
+    suspend fun getMainMenus(): Result<List<MenuModel>>
+
+    suspend fun getSoupMenus(): Result<List<MenuModel>>
+
+    suspend fun getSideMenus(): Result<List<MenuModel>>
 }

--- a/app/src/main/java/com/seom/banchan/domain/usecase/GetMainMenusUseCase.kt
+++ b/app/src/main/java/com/seom/banchan/domain/usecase/GetMainMenusUseCase.kt
@@ -1,0 +1,25 @@
+package com.seom.banchan.domain.usecase
+
+import com.seom.banchan.di.IODispatcher
+import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
+import com.seom.banchan.domain.repository.MenuRepository
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * 카테고리가 있는 메뉴 리스트 요청
+ */
+@ViewModelScoped
+class GetMainMenusUseCase @Inject constructor(
+    private val menuRepository: MenuRepository,
+    @IODispatcher
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend operator fun invoke(): Result<List<MenuModel>> = withContext(ioDispatcher) {
+        menuRepository.getMainMenus()
+    }
+}

--- a/app/src/main/java/com/seom/banchan/domain/usecase/GetSideMenusUseCase.kt
+++ b/app/src/main/java/com/seom/banchan/domain/usecase/GetSideMenusUseCase.kt
@@ -1,0 +1,25 @@
+package com.seom.banchan.domain.usecase
+
+import com.seom.banchan.di.IODispatcher
+import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
+import com.seom.banchan.domain.repository.MenuRepository
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * 카테고리가 있는 메뉴 리스트 요청
+ */
+@ViewModelScoped
+class GetSideMenusUseCase @Inject constructor(
+    private val menuRepository: MenuRepository,
+    @IODispatcher
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend operator fun invoke(): Result<List<MenuModel>> = withContext(ioDispatcher) {
+        menuRepository.getSideMenus()
+    }
+}

--- a/app/src/main/java/com/seom/banchan/domain/usecase/GetSoupMenusUseCase.kt
+++ b/app/src/main/java/com/seom/banchan/domain/usecase/GetSoupMenusUseCase.kt
@@ -1,0 +1,25 @@
+package com.seom.banchan.domain.usecase
+
+import com.seom.banchan.di.IODispatcher
+import com.seom.banchan.domain.model.CategoryModel
+import com.seom.banchan.domain.model.MenuModel
+import com.seom.banchan.domain.repository.MenuRepository
+import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * 카테고리가 있는 메뉴 리스트 요청
+ */
+@ViewModelScoped
+class GetSoupMenusUseCase @Inject constructor(
+    private val menuRepository: MenuRepository,
+    @IODispatcher
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    suspend operator fun invoke(): Result<List<MenuModel>> = withContext(ioDispatcher) {
+        menuRepository.getSoupMenus()
+    }
+}


### PR DESCRIPTION
#### 📌 Summary
메인화면에서 기획전 이외 탭과 관련된 viewModel과 usecase, repository 등의 아키텍처 요소 생성하고
정해진 API로부터 기획전 데이터를 받아오는 작업 진행

#### 🍿 Main Changes
- [x] '기획전' 데이터를 서버로부터 받아오기(로그로 확인)

#### 🔥 UseCase
banchan/data , banchan/domain 확인

#### 🛠 Related Issue
#18
