### PR TITLE
[FEATURE] #11 '메인 화면 '기획전 이외 탭' 화면 스피너 UI

### DIFF
--- a/app/src/main/java/com/seom/banchan/data/api/SortCriteria.kt
+++ b/app/src/main/java/com/seom/banchan/data/api/SortCriteria.kt
@@ -1,0 +1,8 @@
+package com.seom.banchan.data.api
+
+enum class SortCriteria {
+    BASE,
+    ASCENDING,
+    DESCENDING,
+    DISCOUNT_RATE
+}

--- a/app/src/main/java/com/seom/banchan/ui/adapter/SortSpinnerAdapter.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/SortSpinnerAdapter.kt
@@ -1,0 +1,37 @@
+package com.seom.banchan.ui.adapter
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import com.seom.banchan.R
+import com.seom.banchan.databinding.ItemSpinnerBinding
+import com.seom.banchan.databinding.LayoutSpinnerBinding
+import com.seom.banchan.ui.model.Sort
+
+class SortSpinnerAdapter(
+    context : Context,
+    private val items : List<Sort>
+) : ArrayAdapter<Sort>(context, R.layout.item_spinner,items) {
+
+    override fun getCount() = items.size
+
+    override fun getItem(position: Int) = items[position]
+
+    @SuppressLint("ViewHolder")
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val binding = LayoutSpinnerBinding.inflate(LayoutInflater.from(parent.context),parent, false )
+        binding.tvOrder.text = context.getString(getItem(position).name)
+        return binding.root
+    }
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val binding = ItemSpinnerBinding.inflate(LayoutInflater.from(parent.context),parent, false )
+        binding.tvOrder.text = context.getString(getItem(position).name)
+        binding.ivCheck.visibility =
+            if(getItem(position).isChecked) View.VISIBLE else View.GONE
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/seom/banchan/ui/adapter/SortSpinnerAdapter.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/SortSpinnerAdapter.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import com.seom.banchan.R
+import com.seom.banchan.data.api.SortCriteria
 import com.seom.banchan.databinding.ItemSpinnerBinding
 import com.seom.banchan.databinding.LayoutSpinnerBinding
 import com.seom.banchan.ui.model.Sort
@@ -34,4 +35,5 @@ class SortSpinnerAdapter(
             if(getItem(position).isChecked) View.VISIBLE else View.GONE
         return binding.root
     }
+
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
@@ -1,5 +1,8 @@
 package com.seom.banchan.ui.adapter.viewholder.home
 
+import android.view.View
+import android.widget.AdapterView
+import androidx.core.view.get
 import com.seom.banchan.databinding.ItemHomeTotalBinding
 import com.seom.banchan.ui.adapter.SortSpinnerAdapter
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
@@ -11,6 +14,32 @@ class TotalViewHolder (
 
     override fun bind(model: TotalMenuModel) {
         binding.total = model
-        binding.spSort.adapter = SortSpinnerAdapter(binding.root.context,model.sortByItems )
+        val adapter = SortSpinnerAdapter(
+            context= binding.root.context,
+            items = model.sortByItems,
+        )
+        binding.spSort.adapter = adapter
+        binding.spSort.onItemSelectedListener =
+            object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(
+                    adapterView: AdapterView<*>?,
+                    view: View?,
+                    position: Int,
+                    id: Long
+                ) {
+                    model.run {
+                        onSort(model.sortByItems[position].sortCriteria)
+                        sortByItems.forEachIndexed { idx, item ->
+                            item.isChecked = position == idx
+                        }
+                    }
+                }
+
+                override fun onNothingSelected(p0: AdapterView<*>?) {
+
+                }
+
+            }
+
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
@@ -1,12 +1,9 @@
 package com.seom.banchan.ui.adapter.viewholder.home
 
-import android.util.Log
-import com.seom.banchan.databinding.ItemHomeFilterBinding
 import com.seom.banchan.databinding.ItemHomeTotalBinding
+import com.seom.banchan.ui.adapter.SortSpinnerAdapter
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
-import com.seom.banchan.ui.model.home.FilterMenuModel
 import com.seom.banchan.ui.model.home.TotalMenuModel
-import javax.inject.Inject
 
 class TotalViewHolder (
     private val binding: ItemHomeTotalBinding
@@ -14,5 +11,6 @@ class TotalViewHolder (
 
     override fun bind(model: TotalMenuModel) {
         binding.total = model
+        binding.spSort.adapter = SortSpinnerAdapter(binding.root.context,model.sortByItems )
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/home/sidedish/SideDishFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/sidedish/SideDishFragment.kt
@@ -58,7 +58,10 @@ class SideDishFragment : Fragment() {
                     ),
                     TotalMenuModel(
                         id = getString(R.string.total_view_holder),
-                        count = it.size
+                        count = it.size,
+                        onSort = {
+
+                        }
                     )
                 ) + it)
             }

--- a/app/src/main/java/com/seom/banchan/ui/home/soupdish/SoupDishFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/soupdish/SoupDishFragment.kt
@@ -58,7 +58,10 @@ class SoupDishFragment : Fragment() {
                         ),
                         TotalMenuModel(
                             id = getString(R.string.total_view_holder),
-                            count = it.size
+                            count = it.size,
+                            onSort = {
+                                viewModel.updateSort(it)
+                            }
                         )
                     ) + it
                 )

--- a/app/src/main/java/com/seom/banchan/ui/home/soupdish/SoupDishViewModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/soupdish/SoupDishViewModel.kt
@@ -1,8 +1,10 @@
 package com.seom.banchan.ui.home.soupdish
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.seom.banchan.R
+import com.seom.banchan.data.api.SortCriteria
 import com.seom.banchan.domain.model.*
 import com.seom.banchan.domain.usecase.GetSoupMenusUseCase
 import com.seom.banchan.ui.model.Model
@@ -31,5 +33,9 @@ class SoupDishViewModel @Inject constructor(
             .onFailure {
                 println(it)
             }
+    }
+
+    fun updateSort(sortCriteria: SortCriteria) {
+        Log.d("sort Start",sortCriteria.name)
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/model/Sort.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/Sort.kt
@@ -1,0 +1,30 @@
+package com.seom.banchan.ui.model
+
+import androidx.annotation.StringRes
+import com.seom.banchan.R
+import com.seom.banchan.data.api.SortCriteria
+
+data class Sort(
+    @StringRes val name : Int,
+    val sortCriteria: SortCriteria,
+    var isChecked : Boolean = false
+)
+fun defaultSortItems() = listOf(
+    Sort(
+        R.string.sort_base,
+        SortCriteria.BASE,
+        true
+    ),
+    Sort(
+        R.string.sort_descending,
+        SortCriteria.DESCENDING
+    ),
+    Sort(
+        R.string.sort_ascending,
+        SortCriteria.ASCENDING
+    ),
+    Sort(
+        R.string.sort_discount,
+        SortCriteria.DISCOUNT_RATE
+    )
+)

--- a/app/src/main/java/com/seom/banchan/ui/model/home/TotalMenuModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/home/TotalMenuModel.kt
@@ -2,9 +2,12 @@ package com.seom.banchan.ui.model.home
 
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.ui.model.Sort
+import com.seom.banchan.ui.model.defaultSortItems
 
 data class TotalMenuModel(
     override val id: String,
     override val type: CellType = CellType.TOTAL_CELL,
-    val count : Int
+    val count : Int,
+    val sortByItems : List<Sort> = defaultSortItems()
 ) : Model(id, type)

--- a/app/src/main/java/com/seom/banchan/ui/model/home/TotalMenuModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/home/TotalMenuModel.kt
@@ -1,5 +1,6 @@
 package com.seom.banchan.ui.model.home
 
+import com.seom.banchan.data.api.SortCriteria
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
 import com.seom.banchan.ui.model.Sort
@@ -9,5 +10,6 @@ data class TotalMenuModel(
     override val id: String,
     override val type: CellType = CellType.TOTAL_CELL,
     val count : Int,
-    val sortByItems : List<Sort> = defaultSortItems()
+    val sortByItems : List<Sort> = defaultSortItems(),
+    val onSort : (SortCriteria) -> Unit
 ) : Model(id, type)

--- a/app/src/main/res/drawable/background_dropdown.xml
+++ b/app/src/main/res/drawable/background_dropdown.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="rectangle"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <padding
+        android:left="16dp"
+        android:right="16dp"
+        android:bottom="12dp"
+        android:top="12dp"/>
+    <solid android:color="@color/greyScaleWhite"/>
+    <corners android:radius="14dp"/>
+    <stroke android:color="@color/greyScaleLine"
+        android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/selector_spinner.xml
+++ b/app/src/main/res/drawable/selector_spinner.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_window_focused="true"
+        android:drawable="@drawable/ic_down"
+       />
+    <item android:state_window_focused="false">
+        <rotate
+            android:fromDegrees="180"
+            android:toDegrees="180"
+            android:pivotX="50%"
+            android:pivotY="50%"
+            android:drawable="@drawable/ic_down"
+           />
+    </item>
+</selector>

--- a/app/src/main/res/layout/item_home_filter.xml
+++ b/app/src/main/res/layout/item_home_filter.xml
@@ -43,16 +43,6 @@
                 android:checked="false" />
         </RadioGroup>
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/sort_base"
-            android:textColor="@color/greyScaleBlack"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/sp_sort"
-            app:layout_constraintTop_toTopOf="parent" />
-
-
         <androidx.appcompat.widget.AppCompatSpinner
             android:id="@+id/sp_sort"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_home_total.xml
+++ b/app/src/main/res/layout/item_home_total.xml
@@ -13,9 +13,9 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
+        android:layout_height="24dp"
         android:layout_marginVertical="24dp"
-        android:paddingHorizontal="16dp"
-        android:layout_height="24dp">
+        android:layout_marginHorizontal="16dp">
 
         <androidx.appcompat.widget.AppCompatTextView
             android:layout_width="wrap_content"
@@ -27,20 +27,17 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.appcompat.widget.AppCompatTextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/sort_base"
-            android:textColor="@color/greyScaleBlack"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/sp_sort"
-            app:layout_constraintTop_toTopOf="parent" />
-
 
         <androidx.appcompat.widget.AppCompatSpinner
             android:id="@+id/sp_sort"
-            android:layout_width="wrap_content"
+            android:layout_width="124dp"
             android:layout_height="wrap_content"
+            android:background="@null"
+            android:dropDownWidth="110dp"
+            android:dropDownVerticalOffset="8dp"
+            android:gravity="end"
+            android:overlapAnchor="false"
+            android:popupBackground="@drawable/background_dropdown"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_spinner.xml
+++ b/app/src/main/res/layout/item_spinner.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="114dp"
+    android:layout_height="wrap_content"
+    android:paddingVertical="4dp"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_order"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/greyScaleBlack"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/sort_base"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/iv_check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_check"
+        android:tint="@color/primaryAccent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_spinner.xml
+++ b/app/src/main/res/layout/layout_spinner.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tv_order"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/greyScaleBlack"
+        android:layout_marginEnd="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/iv_down"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/sort_base"/>
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/iv_down"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_spinner"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#### 📌 Summary
메인 화면 '기획전 이외 탭'(튼튼한 메인요리, 뜨끈한 국물요리, 정갈한 밑반찬)에서 사용하는 Spinner 구현
(이번 PR에서는 국물 요리, 밑반찬에 적요, 메인 요리에는 적용 X)

#### 🍿 Main Changes
주요 변경 사항
- [x] Spinner 관련 layout 추가
- [x] SpinnerAdapter 추가
- [x] 총 상품 개수와 정렬 포함된 ViewHolder 추가
- [x] Sort관련 Model 추가(Order 사용하려 했으나 이후 화면인 주문 내역 화면 등의 Order와 겹칠 것 같아 sort로 하였음)

#### 🔥 UseCase
<img width="250" src="https://user-images.githubusercontent.com/50227341/184532271-c273e394-51e9-490c-b4e5-4759505d60b6.png">


#### 🛠 Related Issue
#11
