### PR TITLE
[FEATURE] #8 '상세 화면' 하단 메뉴 개수 선택 및 버튼 UI 추가하기

### DIFF
--- a/app/src/main/java/com/seom/banchan/domain/model/home/MenuModel.kt
+++ b/app/src/main/java/com/seom/banchan/domain/model/home/MenuModel.kt
@@ -3,6 +3,7 @@ package com.seom.banchan.domain.model.home
 import com.seom.banchan.ui.model.home.HomeMenuGridModel
 import com.seom.banchan.ui.model.home.HomeMenuLinearModel
 import com.seom.banchan.ui.model.home.HomeMenuModel
+import java.io.Serializable
 import java.lang.Math.ceil
 
 data class MenuModel(
@@ -13,7 +14,7 @@ data class MenuModel(
     val description: String,
     val salePrice: Int,
     val normalPrice: Int
-)
+): Serializable
 
 fun MenuModel.toHomeMenuModel() = HomeMenuModel(
     id = id,

--- a/app/src/main/java/com/seom/banchan/ui/adapter/ModelRecyclerAdapter.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/ModelRecyclerAdapter.kt
@@ -6,9 +6,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.util.listener.ModelAdapterListener
 import com.seom.banchan.util.mapper.ModelViewHolderMapper
 
-class ModelRecyclerAdapter<M : Model> : RecyclerView.Adapter<ModelViewHolder<M>>() {
+class ModelRecyclerAdapter<M : Model>(
+    private val modelAdapterListener: ModelAdapterListener? = null
+) : RecyclerView.Adapter<ModelViewHolder<M>>() {
 
     // recyclerview 에 보여줄 list
     private var modelList: List<Model> = emptyList()
@@ -22,7 +25,9 @@ class ModelRecyclerAdapter<M : Model> : RecyclerView.Adapter<ModelViewHolder<M>>
 
     @Suppress("UNCHECKED_CAST")
     override fun onBindViewHolder(holder: ModelViewHolder<M>, position: Int) {
-        holder.bind(modelList[position] as M)
+        val model = modelList[position] as M
+        holder.bindData(model = model)
+        holder.bindViews(model = model, menuAdapterListener = modelAdapterListener)
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/ModelViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/ModelViewHolder.kt
@@ -3,9 +3,15 @@ package com.seom.banchan.ui.adapter.viewholder
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.util.listener.ModelAdapterListener
 
 abstract class ModelViewHolder<M : Model>(
     binding: ViewBinding
 ) : RecyclerView.ViewHolder(binding.root) {
-    open fun bind(model: M) {}
+    open fun bindData(model: M) {}
+    open fun bindViews(
+        model: M,
+        menuAdapterListener: ModelAdapterListener?
+    ) {
+    }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/DetailBottomButtonViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/DetailBottomButtonViewHolder.kt
@@ -1,0 +1,20 @@
+package com.seom.banchan.ui.adapter.viewholder.detail
+
+import com.seom.banchan.databinding.ItemDetailBottomButtonBinding
+import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
+import com.seom.banchan.ui.model.detail.DetailBottomButtonModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DetailBottomButtonViewHolder(
+    private val binding: ItemDetailBottomButtonBinding
+): ModelViewHolder<DetailBottomButtonModel>(binding) {
+    override fun bindData(model: DetailBottomButtonModel) {
+        CoroutineScope(Dispatchers.IO).launch {
+            model.totalCount.collect {
+                binding.totalPrice = it
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuCountViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuCountViewHolder.kt
@@ -3,11 +3,29 @@ package com.seom.banchan.ui.adapter.viewholder.detail
 import com.seom.banchan.databinding.ItemDetailCountBinding
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
 import com.seom.banchan.ui.model.detail.MenuCountModel
+import com.seom.banchan.util.listener.ModelAdapterListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MenuCountViewHolder(
     private val binding: ItemDetailCountBinding
 ) : ModelViewHolder<MenuCountModel>(binding) {
     override fun bindData(model: MenuCountModel) {
-        binding.count = model.count
+        CoroutineScope(Dispatchers.Main).launch {
+            model.count.collect { binding.count = it }
+        }
+    }
+
+    override fun bindViews(
+        model: MenuCountModel,
+        menuAdapterListener: ModelAdapterListener?
+    ) {
+        binding.ivUpCount.setOnClickListener {
+            menuAdapterListener?.onClick(it, model, adapterPosition)
+        }
+        binding.ivDownCount.setOnClickListener {
+            menuAdapterListener?.onClick(it, model, adapterPosition)
+        }
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuCountViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuCountViewHolder.kt
@@ -1,0 +1,13 @@
+package com.seom.banchan.ui.adapter.viewholder.detail
+
+import com.seom.banchan.databinding.ItemDetailCountBinding
+import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
+import com.seom.banchan.ui.model.detail.MenuCountModel
+
+class MenuCountViewHolder(
+    private val binding: ItemDetailCountBinding
+) : ModelViewHolder<MenuCountModel>(binding) {
+    override fun bindData(model: MenuCountModel) {
+        binding.count = model.count
+    }
+}

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuInfoViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/detail/MenuInfoViewHolder.kt
@@ -16,7 +16,7 @@ class MenuInfoViewHolder(
     private val binding: ItemMenuInfoBinding
 ) : ModelViewHolder<DetailMenuUiModel>(binding) {
 
-    override fun bind(model: DetailMenuUiModel) {
+    override fun bindData(model: DetailMenuUiModel) {
         binding.detail = model
 
         initViewPager(model.detailMenu.images)

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/BestMenuViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/BestMenuViewHolder.kt
@@ -1,5 +1,6 @@
 package com.seom.banchan.ui.adapter.viewholder.home
 
+import android.view.MotionEvent
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.seom.banchan.databinding.ItemBestMenuBinding
@@ -7,15 +8,21 @@ import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
 import com.seom.banchan.ui.model.home.CategoryMenuModel
 import com.seom.banchan.ui.model.home.HomeMenuModel
+import com.seom.banchan.util.listener.ModelAdapterListener
 
 class BestMenuViewHolder(
     private val binding: ItemBestMenuBinding
 ) : ModelViewHolder<CategoryMenuModel>(binding) {
 
-    override fun bind(model: CategoryMenuModel) {
+    override fun bindData(model: CategoryMenuModel) {
         binding.tvCategoryName.text = model.categoryName
+    }
 
-        val bestMenuAdapter = ModelRecyclerAdapter<HomeMenuModel>()
+    override fun bindViews(
+        model: CategoryMenuModel,
+        menuAdapterListener: ModelAdapterListener?
+    ) {
+        val bestMenuAdapter = ModelRecyclerAdapter<HomeMenuModel>(menuAdapterListener)
         binding.rvBest.layoutManager =
             LinearLayoutManager(binding.root.context, LinearLayoutManager.HORIZONTAL, false)
         binding.rvBest.adapter = bestMenuAdapter

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/FilterViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/FilterViewHolder.kt
@@ -8,7 +8,7 @@ class FilterViewHolder (
     private val binding: ItemHomeFilterBinding
 ) : ModelViewHolder<FilterMenuModel>(binding) {
 
-    override fun bind(model: FilterMenuModel) {
+    override fun bindData(model: FilterMenuModel) {
         binding.filter = model
         binding.rgFilter.setOnCheckedChangeListener { _, _ ->
             model.onToggle(

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/HeaderViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/HeaderViewHolder.kt
@@ -11,7 +11,7 @@ class HeaderViewHolder (
     private val binding: ItemHomeHeaderBinding
 ) : ModelViewHolder<HeaderMenuModel>(binding) {
 
-    override fun bind(model: HeaderMenuModel) {
+    override fun bindData(model: HeaderMenuModel) {
         // TODO 중복 코드 방지 필요
         binding.tvHeader.text = binding.root.context.getString(model.title)
         binding.tvChip.isVisible = model.chipTitle != null

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/home/TotalViewHolder.kt
@@ -12,7 +12,7 @@ class TotalViewHolder (
     private val binding: ItemHomeTotalBinding
 ) : ModelViewHolder<TotalMenuModel>(binding) {
 
-    override fun bind(model: TotalMenuModel) {
+    override fun bindData(model: TotalMenuModel) {
         binding.total = model
         val adapter = SortSpinnerAdapter(
             context= binding.root.context,

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/image/ImageListItemViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/image/ImageListItemViewHolder.kt
@@ -8,7 +8,7 @@ import com.seom.banchan.ui.model.imageSlider.ImageSliderModel
 class ImageListItemViewHolder(
     private val binding: ItemImageListBinding
 ): ModelViewHolder<ImageSliderModel>(binding) {
-    override fun bind(model: ImageSliderModel) {
+    override fun bindData(model: ImageSliderModel) {
         binding.image = model
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/image/ImageSliderViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/image/ImageSliderViewHolder.kt
@@ -7,7 +7,7 @@ import com.seom.banchan.ui.model.imageSlider.ImageSliderModel
 class ImageSliderViewHolder(
     private val binding: ItemImageSliderBinding
 ): ModelViewHolder<ImageSliderModel>(binding) {
-    override fun bind(model: ImageSliderModel) {
+    override fun bindData(model: ImageSliderModel) {
         binding.image = model
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/GridMenuViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/GridMenuViewHolder.kt
@@ -9,7 +9,7 @@ import com.seom.banchan.ui.model.home.HomeMenuModel
 class GridMenuViewHolder(
     private val binding: ItemMenuGridBinding
 ) : ModelViewHolder<HomeMenuGridModel>(binding) {
-    override fun bind(model: HomeMenuGridModel) {
+    override fun bindData(model: HomeMenuGridModel) {
         binding.menu = model
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/LinearMenuViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/LinearMenuViewHolder.kt
@@ -7,7 +7,7 @@ import com.seom.banchan.ui.model.home.HomeMenuLinearModel
 class LinearMenuViewHolder(
     private val binding: ItemMenuLinearBinding
 ) : ModelViewHolder<HomeMenuLinearModel>(binding) {
-    override fun bind(model: HomeMenuLinearModel) {
+    override fun bindData(model: HomeMenuLinearModel) {
         binding.menu = model
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/SmallMenuViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/SmallMenuViewHolder.kt
@@ -17,7 +17,7 @@ class SmallMenuViewHolder(
         menuAdapterListener: ModelAdapterListener?
     ) {
         binding.root.setOnClickListener {
-            menuAdapterListener?.onClick(model)
+            menuAdapterListener?.onClick(it, model, adapterPosition)
         }
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/SmallMenuViewHolder.kt
+++ b/app/src/main/java/com/seom/banchan/ui/adapter/viewholder/menu/SmallMenuViewHolder.kt
@@ -3,11 +3,21 @@ package com.seom.banchan.ui.adapter.viewholder.menu
 import com.seom.banchan.databinding.ItemMenuSmallBinding
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
 import com.seom.banchan.ui.model.home.HomeMenuModel
+import com.seom.banchan.util.listener.ModelAdapterListener
 
 class SmallMenuViewHolder(
     private val binding: ItemMenuSmallBinding
 ) : ModelViewHolder<HomeMenuModel>(binding) {
-    override fun bind(model: HomeMenuModel) {
+    override fun bindData(model: HomeMenuModel) {
         binding.menu = model
+    }
+
+    override fun bindViews(
+        model: HomeMenuModel,
+        menuAdapterListener: ModelAdapterListener?
+    ) {
+        binding.root.setOnClickListener {
+            menuAdapterListener?.onClick(model)
+        }
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/base/BaseFragment.kt
@@ -4,16 +4,17 @@ import android.content.Context
 import androidx.fragment.app.Fragment
 
 open class BaseFragment : Fragment() {
-    lateinit var fragmentNavigation : FragmentNavigation
+    lateinit var fragmentNavigation: FragmentNavigation
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        if(context is FragmentNavigation){ /// MainActivity 가 FragmentNavigation을 구현하고 있기 때문에
+        if (context is FragmentNavigation) { /// MainActivity 가 FragmentNavigation을 구현하고 있기 때문에
             fragmentNavigation = context   /// fragmentNavigation을 통해 구현한 FragmentNavigation에 접근 가능
         }
     }
 
     interface FragmentNavigation {
-        fun addFragment(fragment: Fragment,fragmentTag : String? = null)
+        fun addFragment(fragment: Fragment, fragmentTag: String? = null)
+        fun replaceFragment(fragment: Fragment, fragmentTag: String? = null)
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
@@ -15,6 +15,7 @@ import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
 import com.seom.banchan.ui.model.detail.DetailMenuUiModel
+import com.seom.banchan.ui.model.detail.MenuCountModel
 import com.seom.banchan.ui.model.imageSlider.ImageSliderModel
 import com.seom.banchan.util.ext.fromDpToPx
 import dagger.hilt.android.AndroidEntryPoint
@@ -57,7 +58,10 @@ class DetailFragment : Fragment() {
     }
 
     private fun initRecyclerView(detailMenuUiModel: DetailMenuUiModel) = binding?.let {
-        var detailItem = listOf<Model>(detailMenuUiModel)
+        var detailItem = listOf(
+            detailMenuUiModel,
+            MenuCountModel(id = "menuCount", count = 1)
+        )
         detailMenuUiModel.detailMenu.detailImages?.let { image ->
             detailItem += image.map {
                 ImageSliderModel(imageUrl = it, type = CellType.IMAGE_LIST_CELL)

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.seom.banchan.R
 import com.seom.banchan.databinding.FragmentDetailBinding
 import com.seom.banchan.domain.model.home.MenuModel
 import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
@@ -18,6 +19,7 @@ import com.seom.banchan.ui.model.detail.DetailMenuUiModel
 import com.seom.banchan.ui.model.detail.MenuCountModel
 import com.seom.banchan.ui.model.imageSlider.ImageSliderModel
 import com.seom.banchan.util.ext.fromDpToPx
+import com.seom.banchan.util.listener.ModelAdapterListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -60,7 +62,7 @@ class DetailFragment : Fragment() {
     private fun initRecyclerView(detailMenuUiModel: DetailMenuUiModel) = binding?.let {
         var detailItem = listOf(
             detailMenuUiModel,
-            MenuCountModel(id = "menuCount", count = 1)
+            MenuCountModel(id = "menuCount", count = viewModel.count)
         )
         detailMenuUiModel.detailMenu.detailImages?.let { image ->
             detailItem += image.map {
@@ -71,7 +73,22 @@ class DetailFragment : Fragment() {
         it.rvMenuInfo.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
 
-        val menuDetailAdapter = ModelRecyclerAdapter<Model>()
+        val menuDetailAdapter = ModelRecyclerAdapter<Model>(
+            modelAdapterListener = object : ModelAdapterListener {
+                override fun onClick(view: View, model: Model, position: Int) {
+                    when (model.type) {
+                        CellType.DETAIL_COUNT_CELL -> {
+                            if (view.id == R.id.iv_up_count) {
+                                viewModel.increaseCount()
+                            } else if (view.id == R.id.iv_down_count) {
+                                viewModel.decreaseCount()
+                            }
+                        }
+                        else -> {}
+                    }
+                }
+            }
+        )
         it.rvMenuInfo.adapter = menuDetailAdapter
         menuDetailAdapter.submitList(detailItem)
     }

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
@@ -15,6 +15,7 @@ import com.seom.banchan.domain.model.home.MenuModel
 import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.ui.model.detail.DetailBottomButtonModel
 import com.seom.banchan.ui.model.detail.DetailMenuUiModel
 import com.seom.banchan.ui.model.detail.MenuCountModel
 import com.seom.banchan.ui.model.imageSlider.ImageSliderModel
@@ -62,7 +63,8 @@ class DetailFragment : Fragment() {
     private fun initRecyclerView(detailMenuUiModel: DetailMenuUiModel) = binding?.let {
         var detailItem = listOf(
             detailMenuUiModel,
-            MenuCountModel(id = "menuCount", count = viewModel.count)
+            MenuCountModel(id = "menuCount", count = viewModel.count),
+            DetailBottomButtonModel(id = "bottomButton", totalCount = viewModel.count)
         )
         detailMenuUiModel.detailMenu.detailImages?.let { image ->
             detailItem += image.map {

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
@@ -64,7 +64,7 @@ class DetailFragment : Fragment() {
         var detailItem = listOf(
             detailMenuUiModel,
             MenuCountModel(id = "menuCount", count = viewModel.count),
-            DetailBottomButtonModel(id = "bottomButton", totalCount = viewModel.count)
+            DetailBottomButtonModel(id = "bottomButton", totalCount = viewModel.totalPrice)
         )
         detailMenuUiModel.detailMenu.detailImages?.let { image ->
             detailItem += image.map {

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.seom.banchan.databinding.FragmentDetailBinding
+import com.seom.banchan.domain.model.home.MenuModel
 import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
@@ -20,7 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class DetailFragment: Fragment() {
+class DetailFragment : Fragment() {
     private var _binding: FragmentDetailBinding? = null
     private val binding get() = _binding
 
@@ -37,17 +38,18 @@ class DetailFragment: Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val menu: MenuModel? = arguments?.getSerializable(KEY_MODEL_BUNDLE) as? MenuModel
         lifecycleScope.launch {
             viewModel.detailMenuModel.collect {
                 when (it) {
                     is DetailUiState.Success -> {
-                        println(it.detailMenu)
                         binding?.detail = it.detailMenu
                         initRecyclerView(it.detailMenu)
                         initAppbar()
                     }
                     DetailUiState.UnInitialized -> {
-                        viewModel.fetchData("HBDEF")
+                        viewModel.fetchData(menu)
                     }
                 }
             }
@@ -89,6 +91,16 @@ class DetailFragment: Fragment() {
 
     companion object {
         const val TAG = ".DetailFragment"
-        fun newInstance() = DetailFragment()
+        const val KEY_MODEL_BUNDLE = "SelectedModel"
+
+        fun newInstance(menuModel: MenuModel): DetailFragment {
+            val instance = DetailFragment()
+
+            val bundle = Bundle()
+            bundle.putSerializable(KEY_MODEL_BUNDLE, menuModel)
+            instance.arguments = bundle
+
+            return instance
+        }
     }
 }

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
@@ -3,6 +3,7 @@ package com.seom.banchan.ui.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.seom.banchan.domain.model.detail.toUiModel
+import com.seom.banchan.domain.model.home.MenuModel
 import com.seom.banchan.domain.usecase.GetMenuDetailUseCase
 import com.seom.banchan.ui.model.detail.DetailMenuUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,8 +21,12 @@ class DetailViewModel @Inject constructor(
     val detailMenuModel: StateFlow<DetailUiState>
         get() = _detailMenuUiModel
 
-    fun fetchData(menuId: String) = viewModelScope.launch {
-        getMenuDetailUseCase(menuId)
+    fun fetchData(menu: MenuModel?) = viewModelScope.launch {
+        if (menu == null) {
+            _detailMenuUiModel.value = DetailUiState.Error
+            return@launch
+        }
+        getMenuDetailUseCase(menu.id)
             .onSuccess { _detailMenuUiModel.value = DetailUiState.Success(it.toUiModel()) }
     }
 
@@ -32,4 +37,6 @@ sealed interface DetailUiState {
     data class Success(
         val detailMenu: DetailMenuUiModel
     ) : DetailUiState
+
+    object Error : DetailUiState
 }

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
@@ -10,10 +10,7 @@ import com.seom.banchan.domain.model.home.MenuModel
 import com.seom.banchan.domain.usecase.GetMenuDetailUseCase
 import com.seom.banchan.ui.model.detail.DetailMenuUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -33,6 +30,7 @@ class DetailViewModel @Inject constructor(
     fun increaseCount() = viewModelScope.launch {
         _count.emit(_count.value + 1)
     }
+
     fun decreaseCount() = viewModelScope.launch {
         if (_count.value == 1) return@launch
         _count.emit(_count.value - 1)
@@ -44,7 +42,9 @@ class DetailViewModel @Inject constructor(
             return@launch
         }
         getMenuDetailUseCase(menu.id)
-            .onSuccess { _detailMenuUiModel.value = DetailUiState.Success(it.toUiModel()) }
+            .onSuccess {
+                _detailMenuUiModel.value = DetailUiState.Success(it.toUiModel())
+            }
     }
 
 }

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
@@ -1,5 +1,8 @@
 package com.seom.banchan.ui.detail
 
+import androidx.databinding.ObservableInt
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.seom.banchan.domain.model.detail.toUiModel
@@ -9,6 +12,8 @@ import com.seom.banchan.ui.model.detail.DetailMenuUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,6 +25,18 @@ class DetailViewModel @Inject constructor(
     private val _detailMenuUiModel = MutableStateFlow<DetailUiState>(DetailUiState.UnInitialized)
     val detailMenuModel: StateFlow<DetailUiState>
         get() = _detailMenuUiModel
+
+    // 선택한 음식의 개수
+    private val _count = MutableStateFlow(1)
+    val count = _count.asStateFlow()
+
+    fun increaseCount() = viewModelScope.launch {
+        _count.emit(_count.value + 1)
+    }
+    fun decreaseCount() = viewModelScope.launch {
+        if (_count.value == 1) return@launch
+        _count.emit(_count.value - 1)
+    }
 
     fun fetchData(menu: MenuModel?) = viewModelScope.launch {
         if (menu == null) {

--- a/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/detail/DetailViewModel.kt
@@ -36,6 +36,10 @@ class DetailViewModel @Inject constructor(
         _count.emit(_count.value - 1)
     }
 
+    private val _totalPrice = MutableStateFlow(0)
+    val totalPrice =
+        _totalPrice.asStateFlow().combine(count) { newCount, salePrice -> newCount * salePrice }
+
     fun fetchData(menu: MenuModel?) = viewModelScope.launch {
         if (menu == null) {
             _detailMenuUiModel.value = DetailUiState.Error
@@ -43,6 +47,7 @@ class DetailViewModel @Inject constructor(
         }
         getMenuDetailUseCase(menu.id)
             .onSuccess {
+                _totalPrice.value = it.salePrice
                 _detailMenuUiModel.value = DetailUiState.Success(it.toUiModel())
             }
     }

--- a/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
@@ -41,12 +41,14 @@ class BestFragment : BaseFragment() {
                 override fun onClick(model: Model) {
                     when (model.type) {
                         CellType.MENU_CELL -> {
-                            val menuId = model.id
-                            println(menuId)
-                            fragmentNavigation.addFragment(
-                                DetailFragment.newInstance(),
-                                DetailFragment.TAG
-                            )
+                            (model as? HomeMenuModel)?.menu?.let {
+                                fragmentNavigation.addFragment(
+                                    DetailFragment.newInstance(
+                                        menuModel = it
+                                    ),
+                                    DetailFragment.TAG
+                                )
+                            }
                         } // 메뉴 아이템 클릭
                         else -> {}
                     }

--- a/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
@@ -16,6 +16,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.seom.banchan.databinding.FragmentBestBinding
 import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
 import com.seom.banchan.ui.base.BaseFragment
+import com.seom.banchan.ui.detail.DetailFragment
+import com.seom.banchan.ui.home.HomeFragment
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
 import com.seom.banchan.ui.model.home.CategoryMenuModel
@@ -32,7 +34,25 @@ class BestFragment : BaseFragment() {
 
     private val viewModel: BestViewModel by viewModels()
 
-    private lateinit var homeAdapter: ModelRecyclerAdapter<Model>
+    private val homeAdapter: ModelRecyclerAdapter<Model> by lazy {
+        ModelRecyclerAdapter(
+            modelAdapterListener =
+            object : ModelAdapterListener {
+                override fun onClick(model: Model) {
+                    when (model.type) {
+                        CellType.MENU_CELL -> {
+                            val menuId = model.id
+                            println(menuId)
+                            fragmentNavigation.addFragment(
+                                DetailFragment.newInstance(),
+                                DetailFragment.TAG
+                            )
+                        } // 메뉴 아이템 클릭
+                        else -> {}
+                    }
+                }
+            })
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -63,20 +83,6 @@ class BestFragment : BaseFragment() {
     private fun initRecyclerView() = binding?.let {
         it.rvBest.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
-
-        if (::homeAdapter.isInitialized.not()) {
-            homeAdapter = ModelRecyclerAdapter(
-                modelAdapterListener =
-                object : ModelAdapterListener {
-                    override fun onClick(model: Model) {
-                        when (model.type) {
-                            CellType.MENU_CELL -> {
-                            } // 메뉴 아이템 클릭
-                            else -> {}
-                        }
-                    }
-                })
-        }
         it.rvBest.adapter = homeAdapter
     }
 

--- a/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
@@ -42,7 +42,7 @@ class BestFragment : BaseFragment() {
                     when (model.type) {
                         CellType.MENU_CELL -> {
                             (model as? HomeMenuModel)?.menu?.let {
-                                fragmentNavigation.addFragment(
+                                fragmentNavigation.replaceFragment(
                                     DetailFragment.newInstance(
                                         menuModel = it
                                     ),

--- a/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
@@ -38,7 +38,7 @@ class BestFragment : BaseFragment() {
         ModelRecyclerAdapter(
             modelAdapterListener =
             object : ModelAdapterListener {
-                override fun onClick(model: Model) {
+                override fun onClick(view: View, model: Model, position: Int) {
                     when (model.type) {
                         CellType.MENU_CELL -> {
                             (model as? HomeMenuModel)?.menu?.let {

--- a/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
+++ b/app/src/main/java/com/seom/banchan/ui/home/best/BestFragment.kt
@@ -1,32 +1,38 @@
 package com.seom.banchan.ui.home.best
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.seom.banchan.databinding.FragmentBestBinding
 import com.seom.banchan.ui.adapter.ModelRecyclerAdapter
+import com.seom.banchan.ui.base.BaseFragment
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
 import com.seom.banchan.ui.model.home.CategoryMenuModel
 import com.seom.banchan.ui.model.home.HeaderMenuModel
 import com.seom.banchan.ui.model.home.HomeMenuModel
+import com.seom.banchan.util.listener.ModelAdapterListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class BestFragment : Fragment() {
+class BestFragment : BaseFragment() {
     private var _binding: FragmentBestBinding? = null
     private val binding get() = _binding
 
     private val viewModel: BestViewModel by viewModels()
 
-    private val homeAdapter: ModelRecyclerAdapter<Model> by lazy { ModelRecyclerAdapter() }
+    private lateinit var homeAdapter: ModelRecyclerAdapter<Model>
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -34,7 +40,6 @@ class BestFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentBestBinding.inflate(inflater)
-
         return binding?.root
     }
 
@@ -47,12 +52,31 @@ class BestFragment : Fragment() {
     }
 
     private fun initObserver() {
-        lifecycleScope.launch { viewModel.bestMenus.collect { homeAdapter.submitList(it) } }
+        lifecycleScope.launch {
+            viewModel.bestMenus.collect {
+                homeAdapter.submitList(it)
+            }
+        }
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun initRecyclerView() = binding?.let {
         it.rvBest.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+
+        if (::homeAdapter.isInitialized.not()) {
+            homeAdapter = ModelRecyclerAdapter(
+                modelAdapterListener =
+                object : ModelAdapterListener {
+                    override fun onClick(model: Model) {
+                        when (model.type) {
+                            CellType.MENU_CELL -> {
+                            } // 메뉴 아이템 클릭
+                            else -> {}
+                        }
+                    }
+                })
+        }
         it.rvBest.adapter = homeAdapter
     }
 

--- a/app/src/main/java/com/seom/banchan/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/seom/banchan/ui/main/MainActivity.kt
@@ -46,4 +46,7 @@ class MainActivity : AppCompatActivity(), BaseFragment.FragmentNavigation {
     override fun addFragment(fragment: Fragment, fragmentTag: String?) {
         fragmentNavigationController.addFragment(fragment,fragmentTag)
     }
+    override fun replaceFragment(fragment: Fragment, fragmentTag: String?) {
+        fragmentNavigationController.replaceFragment(fragment, fragmentTag)
+    }
 }

--- a/app/src/main/java/com/seom/banchan/ui/model/CellType.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/CellType.kt
@@ -13,5 +13,6 @@ enum class CellType {
     IMAGE_SLIDER_CELL, // viewpager 이미지
     IMAGE_LIST_CELL, // 이미지 리스트
     MENU_DETAIL_INFO_CELL, // 메뉴 상세 정보
-    DETAIL_COUNT_CELL // 메뉴 개수 변경
+    DETAIL_COUNT_CELL, // 메뉴 개수 변경
+    DETAIL_BOTTOM_BUTTON_CELL // 메뉴 장바구니 추가 버튼 cell
 }

--- a/app/src/main/java/com/seom/banchan/ui/model/CellType.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/CellType.kt
@@ -9,7 +9,9 @@ enum class CellType {
     FILTER_CELL,
     TOTAL_CELL,
 
-    IMAGE_SLIDER_CELL,
-    IMAGE_LIST_CELL,
-    MENU_DETAIL_INFO_CELL
+    // 상세 화면
+    IMAGE_SLIDER_CELL, // viewpager 이미지
+    IMAGE_LIST_CELL, // 이미지 리스트
+    MENU_DETAIL_INFO_CELL, // 메뉴 상세 정보
+    DETAIL_COUNT_CELL // 메뉴 개수 변경
 }

--- a/app/src/main/java/com/seom/banchan/ui/model/detail/DetailBottomButtonModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/detail/DetailBottomButtonModel.kt
@@ -1,0 +1,11 @@
+package com.seom.banchan.ui.model.detail
+
+import com.seom.banchan.ui.model.CellType
+import com.seom.banchan.ui.model.Model
+import kotlinx.coroutines.flow.StateFlow
+
+data class DetailBottomButtonModel(
+    override val id: String,
+    override val type: CellType = CellType.DETAIL_BOTTOM_BUTTON_CELL,
+    val totalCount: StateFlow<Int>
+):Model(id, type)

--- a/app/src/main/java/com/seom/banchan/ui/model/detail/DetailBottomButtonModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/detail/DetailBottomButtonModel.kt
@@ -2,10 +2,10 @@ package com.seom.banchan.ui.model.detail
 
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 data class DetailBottomButtonModel(
     override val id: String,
     override val type: CellType = CellType.DETAIL_BOTTOM_BUTTON_CELL,
-    val totalCount: StateFlow<Int>
+    val totalCount: Flow<Int>
 ):Model(id, type)

--- a/app/src/main/java/com/seom/banchan/ui/model/detail/MenuCountModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/detail/MenuCountModel.kt
@@ -1,0 +1,10 @@
+package com.seom.banchan.ui.model.detail
+
+import com.seom.banchan.ui.model.CellType
+import com.seom.banchan.ui.model.Model
+
+data class MenuCountModel(
+    override val id: String,
+    override val type: CellType = CellType.DETAIL_COUNT_CELL,
+    val count: Int
+) : Model(id, type)

--- a/app/src/main/java/com/seom/banchan/ui/model/detail/MenuCountModel.kt
+++ b/app/src/main/java/com/seom/banchan/ui/model/detail/MenuCountModel.kt
@@ -1,10 +1,12 @@
 package com.seom.banchan.ui.model.detail
 
+import androidx.lifecycle.LiveData
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import kotlinx.coroutines.flow.StateFlow
 
 data class MenuCountModel(
     override val id: String,
     override val type: CellType = CellType.DETAIL_COUNT_CELL,
-    val count: Int
+    val count: StateFlow<Int>
 ) : Model(id, type)

--- a/app/src/main/java/com/seom/banchan/util/listener/ModelAdapterListener.kt
+++ b/app/src/main/java/com/seom/banchan/util/listener/ModelAdapterListener.kt
@@ -1,5 +1,6 @@
 package com.seom.banchan.util.listener
 
+import android.view.View
 import com.seom.banchan.ui.model.Model
 
 /**
@@ -7,5 +8,5 @@ import com.seom.banchan.ui.model.Model
  * 클릭 리스너
  */
 interface ModelAdapterListener {
-    fun onClick(model: Model)
+    fun onClick(view: View, model: Model, position: Int)
 }

--- a/app/src/main/java/com/seom/banchan/util/listener/ModelAdapterListener.kt
+++ b/app/src/main/java/com/seom/banchan/util/listener/ModelAdapterListener.kt
@@ -1,0 +1,11 @@
+package com.seom.banchan.util.listener
+
+import com.seom.banchan.ui.model.Model
+
+/**
+ * model recycler view 에서 발생할 수 있는 아이템
+ * 클릭 리스너
+ */
+interface ModelAdapterListener {
+    fun onClick(model: Model)
+}

--- a/app/src/main/java/com/seom/banchan/util/mapper/ModelViewHolderMapper.kt
+++ b/app/src/main/java/com/seom/banchan/util/mapper/ModelViewHolderMapper.kt
@@ -8,6 +8,7 @@ import com.seom.banchan.databinding.ItemHomeHeaderBinding
 import com.seom.banchan.databinding.ItemImageSliderBinding
 import com.seom.banchan.databinding.ItemMenuSmallBinding
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
+import com.seom.banchan.ui.adapter.viewholder.detail.DetailBottomButtonViewHolder
 import com.seom.banchan.ui.adapter.viewholder.detail.MenuCountViewHolder
 import com.seom.banchan.ui.adapter.viewholder.detail.MenuInfoViewHolder
 import com.seom.banchan.ui.adapter.viewholder.home.BestMenuViewHolder
@@ -21,6 +22,7 @@ import com.seom.banchan.ui.adapter.viewholder.image.ImageSliderViewHolder
 import com.seom.banchan.ui.adapter.viewholder.menu.SmallMenuViewHolder
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.ui.model.detail.DetailBottomButtonModel
 import com.seom.banchan.ui.model.detail.MenuCountModel
 
 object ModelViewHolderMapper {
@@ -64,6 +66,9 @@ object ModelViewHolderMapper {
             )
             CellType.DETAIL_COUNT_CELL -> MenuCountViewHolder(
                 ItemDetailCountBinding.inflate(inflater, parent, false)
+            )
+            CellType.DETAIL_BOTTOM_BUTTON_CELL -> DetailBottomButtonViewHolder(
+                ItemDetailBottomButtonBinding.inflate(inflater, parent, false)
             )
         }
         return viewHolder as ModelViewHolder<M>

--- a/app/src/main/java/com/seom/banchan/util/mapper/ModelViewHolderMapper.kt
+++ b/app/src/main/java/com/seom/banchan/util/mapper/ModelViewHolderMapper.kt
@@ -8,6 +8,7 @@ import com.seom.banchan.databinding.ItemHomeHeaderBinding
 import com.seom.banchan.databinding.ItemImageSliderBinding
 import com.seom.banchan.databinding.ItemMenuSmallBinding
 import com.seom.banchan.ui.adapter.viewholder.ModelViewHolder
+import com.seom.banchan.ui.adapter.viewholder.detail.MenuCountViewHolder
 import com.seom.banchan.ui.adapter.viewholder.detail.MenuInfoViewHolder
 import com.seom.banchan.ui.adapter.viewholder.home.BestMenuViewHolder
 import com.seom.banchan.ui.adapter.viewholder.home.FilterViewHolder
@@ -20,6 +21,7 @@ import com.seom.banchan.ui.adapter.viewholder.image.ImageSliderViewHolder
 import com.seom.banchan.ui.adapter.viewholder.menu.SmallMenuViewHolder
 import com.seom.banchan.ui.model.CellType
 import com.seom.banchan.ui.model.Model
+import com.seom.banchan.ui.model.detail.MenuCountModel
 
 object ModelViewHolderMapper {
 
@@ -59,6 +61,9 @@ object ModelViewHolderMapper {
             )
             CellType.MENU_DETAIL_INFO_CELL -> MenuInfoViewHolder(
                 ItemMenuInfoBinding.inflate(inflater, parent, false)
+            )
+            CellType.DETAIL_COUNT_CELL -> MenuCountViewHolder(
+                ItemDetailCountBinding.inflate(inflater, parent, false)
             )
         }
         return viewHolder as ModelViewHolder<M>

--- a/app/src/main/java/com/seom/banchan/util/navigation/FragmentNavigationController.kt
+++ b/app/src/main/java/com/seom/banchan/util/navigation/FragmentNavigationController.kt
@@ -3,14 +3,22 @@ package com.seom.banchan.util.navigation
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
 
 class FragmentNavigationController(
-    private val fragmentManager : FragmentManager,
-    @IdRes private val containerId : Int
+    private val fragmentManager: FragmentManager,
+    @IdRes private val containerId: Int
 ) {
-    fun addFragment(fragment: Fragment, fragmentTag: String? = null){
-        fragmentManager.beginTransaction().add(containerId,fragment,fragmentTag).commit()
+    fun addFragment(fragment: Fragment, fragmentTag: String? = null) {
+        fragmentManager.beginTransaction().add(containerId, fragment, fragmentTag).commit()
     }
 
     // 필요한 Transaction 추가 ..
+    fun replaceFragment(fragment: Fragment, fragmentTag: String? = null) {
+        fragmentManager.commit {
+            setReorderingAllowed(true)
+            addToBackStack(fragmentTag)
+            replace(containerId, fragment, fragmentTag)
+        }
+    }
 }

--- a/app/src/main/res/drawable/background_button.xml
+++ b/app/src/main/res/drawable/background_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primaryMain" />
+    <corners android:radius="5dp" />
+</shape>

--- a/app/src/main/res/drawable/background_button.xml
+++ b/app/src/main/res/drawable/background_button.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/primaryMain" />
-    <corners android:radius="5dp" />
+    <corners android:radius="2dp" />
 </shape>

--- a/app/src/main/res/drawable/background_rounded_button.xml
+++ b/app/src/main/res/drawable/background_rounded_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/greyScaleLine" />
+    <corners android:radius="999dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_minus.xml
+++ b/app/src/main/res/drawable/ic_minus.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,12H19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#010101"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,5V19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#010101"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,12H19"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#010101"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/item_detail_bottom_button.xml
+++ b/app/src/main/res/layout/item_detail_bottom_button.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="totalPrice"
+            type="Integer" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="24dp">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_total_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="24dp"
+            android:textColor="@color/black"
+            android:textSize="32sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/btn_add_cart"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="spread"
+            app:text="@{@string/menu_price_value(totalPrice)}"
+            tools:text="2,000원" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="24dp"
+            android:text="@string/detail_total_price"
+            android:textColor="@color/greyScaleDefault"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/tv_total_price"
+            app:layout_constraintEnd_toStartOf="@id/tv_total_price"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_total_price" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_add_cart"
+            android:layout_width="match_parent"
+            android:layout_height="45dp"
+            android:background="@drawable/background_button"
+            android:text="@string/detail_add"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_total_price" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_detail_bottom_button.xml
+++ b/app/src/main/res/layout/item_detail_bottom_button.xml
@@ -12,7 +12,7 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="16dp"
+        android:paddingHorizontal="8dp"
         android:paddingVertical="24dp">
 
         <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/item_detail_count.xml
+++ b/app/src/main/res/layout/item_detail_count.xml
@@ -2,7 +2,6 @@
 <layout>
 
     <data>
-
         <variable
             name="count"
             type="Integer" />
@@ -69,7 +68,7 @@
                 app:layout_constraintEnd_toStartOf="@id/iv_up_count"
                 app:layout_constraintStart_toEndOf="@id/iv_down_count"
                 app:layout_constraintTop_toTopOf="parent"
-                app:text="@{count.toString()}" />
+                android:text="@{count.toString()}" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_detail_count.xml
+++ b/app/src/main/res/layout/item_detail_count.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="count"
+            type="Integer" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_total_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/detail_count"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="@id/tv_total_price"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_total_price">
+
+            <androidx.appcompat.widget.AppCompatImageButton
+                android:id="@+id/iv_down_count"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:background="@drawable/background_rounded_button"
+                android:elevation="4dp"
+                android:src="@drawable/ic_minus"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatImageButton
+                android:id="@+id/iv_up_count"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:background="@drawable/background_rounded_button"
+                android:elevation="4dp"
+                android:src="@drawable/ic_plus"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:textColor="@color/black"
+                android:textSize="14sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/iv_up_count"
+                app:layout_constraintStart_toEndOf="@id/iv_down_count"
+                app:layout_constraintTop_toTopOf="parent"
+                app:text="@{count.toString()}" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_detail_count.xml
+++ b/app/src/main/res/layout/item_detail_count.xml
@@ -11,34 +11,38 @@
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="24dp">
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_total_price"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/detail_count"
-            android:textColor="@color/black"
+            android:textColor="@color/greyScaleDefault"
             android:textSize="14sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="@id/tv_total_price"
+            android:layout_width="150dp"
+            android:layout_height="50dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_total_price">
+            app:layout_constraintTop_toTopOf="parent">
 
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/iv_down_count"
                 android:layout_width="44dp"
                 android:layout_height="44dp"
                 android:background="@drawable/background_rounded_button"
-                android:elevation="4dp"
+                android:elevation="2dp"
+                android:layout_margin="5dp"
                 android:src="@drawable/ic_minus"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
@@ -47,8 +51,9 @@
                 android:layout_width="44dp"
                 android:layout_height="44dp"
                 android:background="@drawable/background_rounded_button"
-                android:elevation="4dp"
+                android:elevation="2dp"
                 android:src="@drawable/ic_plus"
+                android:layout_margin="5dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -59,7 +64,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="24dp"
                 android:textColor="@color/black"
-                android:textSize="14sp"
+                android:textSize="18sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/iv_up_count"
                 app:layout_constraintStart_toEndOf="@id/iv_down_count"


### PR DESCRIPTION
#### 📌 Summary
상세 화면 하단에 보이는 개수를 선택할 수 있는 component와
선택한 개수에 따른 총 주문금액, 장바구니 추가 버튼(UI만) component를 구현하였습니다.

추가적으로, 홈 화면의 '기획전'에서 메뉴를 클릭 했을 때, 상세 화면으로 이동할 수 있도록
아래 2가지 기능 또한 추가하였습니다.
1. 홈 화면 이외의 화면(여기서는 상세화면)은 화면 전환 시 fragmentManager에서 replace + addPopStack
2. recyclerview의 deep한 viewholder에서 발생한 이벤트를 받아올 수 있도록 listener implement를 추가하였습니다.
  - adpater를 생성할 때, listener 구현체를 전달해주고, 이벤트가 발생하는 부분에서 해당 구현체의 onClick 메서드를 호출하면 fragment에서 받을 수 있도록 처리하였습니다. 🤗

#### 🍿 Main Changes
##### 홈 화면에서 상세 화면으로 화면전환하기
- [x] 메뉴 아이템 클릭 시, Fragment에서 해당 아이템의 id를 얻을 수 있는 로직 구현하기
- [x] 홈 화면에서 상세 화면으로 Fragment 전환하기
- [x] 상세 화면으로 Fragment 전환할 때, 메뉴 id 전달하기
- [x] 상세 화면에서 백버튼 클릭 시, 이전 화면으로 이동하도록 수정하기

##### 상품 수량 변경 및 총 주문 금액
- [x] 상품 수량 증감 버튼 UI 구현하기
- [x] 하단 '주문버튼' UI 구성하기
- [x] 수량 변경 시, 총 주문금액 표시하기

#### 🔥 UseCase
<img width="350" alt="스크린샷 2022-08-17 오후 3 17 24" src="https://user-images.githubusercontent.com/22411296/185048134-9aa16265-ed44-41ac-b9ae-a9f8be31a0f3.png">

#### 🌹 Todo
1. 현재 동일한 ViewHolder에서 발생한 서로 다른 event를 구분하기 위해서, 각 view의 id를 사용하고 있습니다. 이 부분에 대해서는 이후 수정해볼 예정입니다. 🧐

#### 🛠 Related Issue
Closed #8
Closed #35